### PR TITLE
Fix the TargetFramework

### DIFF
--- a/src/Cake.DevicesXunitTestReceiver/Cake.DevicesXunitTestReceiver.csproj
+++ b/src/Cake.DevicesXunitTestReceiver/Cake.DevicesXunitTestReceiver.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
As far as I know,  `netstandard2` is an incorrect target, the correct target should be `netstandard2.0`.

Also, since you are targeting a single framework, you can use the singular `TargetFramework`.